### PR TITLE
Add support for composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "autoload": {
         "psr-4": {
-            "PostbodeApi\\": "src"
+            "Postbode\\": "src"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "autoload": {
         "psr-4": {
-            "Postbode\\": "src"
+            "PostbodeApi\\": "src"
         }
     },
     "require-dev": {

--- a/src/Postbode/PostbodeClient.php
+++ b/src/Postbode/PostbodeClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Postbode;
+namespace PostbodeApi;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;

--- a/src/PostbodeClient.php
+++ b/src/PostbodeClient.php
@@ -132,7 +132,7 @@ class PostbodeClient
         ];
     }
 
-    public function sendLetterQueue()
+    public function sendLetterQueue($mailbox_id)
     {
         return $this->sendRequest('POST', '/mailbox/'.$mailbox_id.'/letterbatch', $this->letter_queue);
     }

--- a/src/PostbodeClient.php
+++ b/src/PostbodeClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PostbodeApi;
+namespace Postbode;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;


### PR DESCRIPTION
Composer 2.0 is around the corner. As stated on [the composer upgrade guide](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md), `Invalid PSR-0 / PSR-4 class configurations will not autoload anymore in optimized-autoloader mode, as per the warnings introduced in 1.10`. Currently, the name spacing for the `PostbodeClient.php` does not comply with the PSR standards.

This is a breaking change, so you should update the version number accordingly.